### PR TITLE
fix fillter params

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:pass]


### PR DESCRIPTION
before
```
I, [2017-07-05T06:10:18.126698 #11500]  INFO -- : Started POST "/sessions" for 124.35.147.130 at 2017-07-05 06:10:18 +0000
I, [2017-07-05T06:10:18.127583 #11500]  INFO -- : Processing by SessionsController#create as */*
I, [2017-07-05T06:10:18.127777 #11500]  INFO -- :   Parameters: {"user"=>"hoge", "pass"=>"fuga"}
D, [2017-07-05T06:10:18.128782 #11500] DEBUG -- :   User Load (0.4ms)  SELECT  `users`.* FROM `users` WHERE (user='hoge' and pass='c32ec965db3295bad074d2afa907b1c3') LIMIT 1
I, [2017-07-05T06:10:18.129242 #11500]  INFO -- : Completed 400 Bad Request in 1ms (Views: 0.2ms | ActiveRecord: 0.4ms)
```

after

```
Started POST "/sessions" for ::1 at 2017-07-05 15:11:16 +0900
Processing by SessionsController#create as */*
  Parameters: {"user"=>"hofe ", "pass"=>"[FILTERED]"}
  User Load (0.1ms)  SELECT  "users".* FROM "users" WHERE (user='hofe ' and pass='c32ec965db3295bad074d2afa907b1c3') LIMIT 1
Completed 400 Bad Request in 1ms (Views: 0.2ms | ActiveRecord: 0.1ms)
```